### PR TITLE
BASE href, config.json, and cache-control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.18 as builder
 LABEL maintainer="donato@wolfisberg.dev"
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ The following options can be configured through environment variables.
 | READ_TIMEOUT_SECONDS  | 5        | 
 | WRITE_TIMEOUT_SECONDS | 10       |
 | IDLE_TIMEOUT_SECONDS  | 120      |
+| BASE_HREF             | /        |
+| CONFIG_JSON           | {}       |
 
+* `BASE_HREF` is used to replace the `href` content in the `index.html`'s string `<base href="/"`, where the original string must match exactly the one mentioned here
+* `CONFIG_JSON` must be json object that will be provided as the response for the request path `/config.json`
 
+The `Cache-Control` is a one minute validity for `/index.html` and `/config.json`, and immutable for the rest of the responses.
 ## Build local
 
 ```shell

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module spa-server
 
-go 1.16
+go 1.18

--- a/main.go
+++ b/main.go
@@ -71,9 +71,18 @@ func loadFilesFromEmbeddedFs() (map[string]loadedFile, error) {
 				[]byte(fmt.Sprint("<base href=\"", getenvString("BASE_HREF", "/"), "\"")),
 				-1)
 		}
+		mimeType := "application/unknown"
+		switch ext := filepath.Ext(path); ext {
+		case ".woff":
+			mimeType = "font/woff"
+		case ".woff2":
+			mimeType = "font/woff2"
+		default:
+			mimeType = mime.TypeByExtension(filepath.Ext(path))
+		}
 		files[path] = loadedFile{
 			file: file,
-			mime: mime.TypeByExtension(filepath.Ext(path)),
+			mime: mimeType,
 		}
 		log.Printf("Loading file from embeded filessystem. file %s\n", path)
 		return nil


### PR DESCRIPTION
I added some minor enhancements: 

- BASE_HREF env can be used as substitute for the <base href="/"> to enable hosting of SPA under sub-paths with easy configuration. 
- CONFIG_JSON to provide content of the "/config.json" path which allows to "configure" SPA for various  deployments
- adding some default Cache-Control for efficient caching of SPA assets

Consider to merge into your version. 